### PR TITLE
[tool] use stable rust toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable


### PR DESCRIPTION
`nightly` triggers a new build each day https://github.com/topgrade-rs/topgrade is run, making it quite long
`stable` is enough for with the current rust submissions

All in all, better avoid `nightly` as we can afford it