### PR TITLE
Remove run from rust lib

### DIFF
--- a/day-01/part-1/enizor.rs
+++ b/day-01/part-1/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> u32 {

--- a/day-01/part-1/paullgdc.rs
+++ b/day-01/part-1/paullgdc.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {
@@ -9,7 +16,7 @@ fn run(input: &str) -> usize {
             if line.is_empty() {
                 let total = load;
                 load = 0;
-                return Some(total)
+                return Some(total);
             }
             load += line.parse::<usize>().unwrap();
             last.then_some(load)

--- a/day-01/part-2/enizor.rs
+++ b/day-01/part-2/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-01/part-2/paullgdc.rs
+++ b/day-01/part-2/paullgdc.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-02/part-1/badouralix.rs
+++ b/day-02/part-1/badouralix.rs
@@ -1,3 +1,6 @@
+use std::env::args;
+use std::time::Instant;
+
 #[derive(PartialEq)]
 enum HandShape {
     Paper,
@@ -19,7 +22,11 @@ impl TryFrom<isize> for HandShape {
 }
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-02/part-1/enizor.rs
+++ b/day-02/part-1/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const A: u64 = b'A' as u64;

--- a/day-02/part-1/jd.rs
+++ b/day-02/part-1/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-02/part-1/paullgdc.rs
+++ b/day-02/part-1/paullgdc.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-02/part-1/thomren.rs
+++ b/day-02/part-1/thomren.rs
@@ -13,7 +13,7 @@ fn run(input: &str) -> usize {
     input.lines().map(compute_score).sum()
 }
 
-fn compute_score(line:  &str) -> usize {
+fn compute_score(line: &str) -> usize {
     let line = line.as_bytes();
     let opponent_move = line[0] - b'A';
     let elve_move = line[2] - b'X';

--- a/day-02/part-2/badouralix.rs
+++ b/day-02/part-2/badouralix.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-02/part-2/enizor.rs
+++ b/day-02/part-2/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const A: u64 = b'A' as u64;

--- a/day-02/part-2/jd.rs
+++ b/day-02/part-2/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-02/part-2/paullgdc.rs
+++ b/day-02/part-2/paullgdc.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {
@@ -17,7 +24,6 @@ fn run(input: &str) -> isize {
 
     total
 }
-
 
 fn score(round: [u8; 4]) -> u8 {
     (round[0] - b'A' + (round[2] - b'X') + 2) % 3 + 1 + (round[2] - b'X') * 3

--- a/day-02/part-2/thomren.rs
+++ b/day-02/part-2/thomren.rs
@@ -13,7 +13,7 @@ fn run(input: &str) -> usize {
     input.lines().map(compute_score).sum()
 }
 
-fn compute_score(line:  &str) -> usize {
+fn compute_score(line: &str) -> usize {
     let line = line.as_bytes();
     let opponent_move = line[0] - b'A';
     let outcome = line[2] - b'X';
@@ -21,7 +21,7 @@ fn compute_score(line:  &str) -> usize {
         0 => (opponent_move as isize - 1).rem_euclid(3),
         1 => opponent_move as isize,
         2 => (opponent_move as isize + 1) % 3,
-        _ => panic!("invalid outcome: {}", line[2])
+        _ => panic!("invalid outcome: {}", line[2]),
     } as usize;
     3 * outcome as usize + elve_move + 1
 }

--- a/day-03/part-1/badouralix.rs
+++ b/day-03/part-1/badouralix.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-03/part-1/enizor.rs
+++ b/day-03/part-1/enizor.rs
@@ -1,7 +1,13 @@
 use aoc::enizor::bitset::{bitset_size, ArrayBitSet};
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const N: usize = bitset_size(b'z' as usize - b'A' as usize + 1);

--- a/day-03/part-1/jd.rs
+++ b/day-03/part-1/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-03/part-1/paullgdc.rs
+++ b/day-03/part-1/paullgdc.rs
@@ -1,7 +1,13 @@
+use std::env::args;
 use std::hint::unreachable_unchecked;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 struct RuckSack(u64);

--- a/day-03/part-1/thomren.rs
+++ b/day-03/part-1/thomren.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-03/part-2/badouralix.rs
+++ b/day-03/part-2/badouralix.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-03/part-2/enizor.rs
+++ b/day-03/part-2/enizor.rs
@@ -1,8 +1,15 @@
 use aoc::enizor::bitset::{bitset_size, ArrayBitSet};
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
+
 const N: usize = bitset_size(b'z' as usize - b'A' as usize + 1);
 type RuckSack = ArrayBitSet<N>;
 

--- a/day-03/part-2/jd.rs
+++ b/day-03/part-2/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-03/part-2/paullgdc.rs
+++ b/day-03/part-2/paullgdc.rs
@@ -1,7 +1,13 @@
+use std::env::args;
 use std::hint::unreachable_unchecked;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 struct RuckSack(u64);

--- a/day-03/part-2/thomren.rs
+++ b/day-03/part-2/thomren.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const GROUP_SIZE: usize = 3;
@@ -38,7 +45,7 @@ fn get_bytes_set(line: &str) -> u128 {
 
 /// Base 2 logarithm of a u128
 fn ilog(x: u128) -> u32 {
-  x.next_power_of_two().trailing_zeros()
+    x.next_power_of_two().trailing_zeros()
 }
 
 fn priority(c: u8) -> usize {

--- a/day-04/part-1/badouralix.rs
+++ b/day-04/part-1/badouralix.rs
@@ -1,7 +1,12 @@
-use std::isize;
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-04/part-1/enizor.rs
+++ b/day-04/part-1/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-04/part-1/jd.rs
+++ b/day-04/part-1/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-04/part-1/paullgdc.rs
+++ b/day-04/part-1/paullgdc.rs
@@ -1,9 +1,15 @@
+use std::env::args;
 use std::ops::RangeInclusive;
+use std::time::Instant;
 
 use aoc::paullgdc::tokenize::Tokenizer;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn parse_range(range: &mut Tokenizer) -> Option<RangeInclusive<u8>> {

--- a/day-04/part-1/thomren.rs
+++ b/day-04/part-1/thomren.rs
@@ -1,19 +1,22 @@
+use std::env::args;
+use std::error::Error;
 use std::slice::Iter;
 use std::str::FromStr;
-use std::error::Error;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {
     input
         .lines()
         .map(|line| AssignementPair::from_str(line).unwrap())
-        .filter(|AssignementPair(a, b)| 
-            b.0 <= a.0 && a.1 <= b.1 || 
-            a.0 <= b.0 && b.1 <= a.1
-        )
+        .filter(|AssignementPair(a, b)| b.0 <= a.0 && a.1 <= b.1 || a.0 <= b.0 && b.1 <= a.1)
         .count()
 }
 
@@ -28,12 +31,12 @@ impl FromStr for AssignementPair {
         let mut it = s.as_bytes().iter();
         let first_min = atoi(it.by_ref());
         let first_max = atoi(it.by_ref());
-        let second_min= atoi(it.by_ref());
+        let second_min = atoi(it.by_ref());
         let second_max = atoi(it.by_ref());
 
         let res = AssignementPair(
-            Assignement(first_min, first_max), 
-            Assignement(second_min, second_max)
+            Assignement(first_min, first_max),
+            Assignement(second_min, second_max),
         );
         Ok(res)
     }
@@ -45,7 +48,7 @@ fn atoi(it: &mut Iter<u8>) -> usize {
     let mut res = 0;
     for &b in it {
         match b {
-            b'0'..=b'9' => {},
+            b'0'..=b'9' => {}
             _ => break,
         }
         res *= 10;

--- a/day-04/part-2/badouralix.rs
+++ b/day-04/part-2/badouralix.rs
@@ -1,7 +1,12 @@
-use std::isize;
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-04/part-2/enizor.rs
+++ b/day-04/part-2/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {

--- a/day-04/part-2/jd.rs
+++ b/day-04/part-2/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-04/part-2/paullgdc.rs
+++ b/day-04/part-2/paullgdc.rs
@@ -1,9 +1,15 @@
+use std::env::args;
 use std::ops::RangeInclusive;
+use std::time::Instant;
 
 use aoc::paullgdc::tokenize::Tokenizer;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn parse_range(range: &mut Tokenizer) -> Option<RangeInclusive<u8>> {

--- a/day-04/part-2/thomren.rs
+++ b/day-04/part-2/thomren.rs
@@ -1,19 +1,22 @@
+use std::env::args;
+use std::error::Error;
 use std::slice::Iter;
 use std::str::FromStr;
-use std::error::Error;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {
     input
         .lines()
         .map(|line| AssignementPair::from_str(line).unwrap())
-        .filter(|AssignementPair(a, b)| 
-            b.0 <= a.0 && a.0 <= b.1 || 
-            a.0 <= b.0 && b.0 <= a.1
-        )
+        .filter(|AssignementPair(a, b)| b.0 <= a.0 && a.0 <= b.1 || a.0 <= b.0 && b.0 <= a.1)
         .count()
 }
 
@@ -28,12 +31,12 @@ impl FromStr for AssignementPair {
         let mut it = s.as_bytes().iter();
         let first_min = atoi(it.by_ref());
         let first_max = atoi(it.by_ref());
-        let second_min= atoi(it.by_ref());
+        let second_min = atoi(it.by_ref());
         let second_max = atoi(it.by_ref());
 
         let res = AssignementPair(
-            Assignement(first_min, first_max), 
-            Assignement(second_min, second_max)
+            Assignement(first_min, first_max),
+            Assignement(second_min, second_max),
         );
         Ok(res)
     }
@@ -45,7 +48,7 @@ fn atoi(it: &mut Iter<u8>) -> usize {
     let mut res = 0;
     for &b in it {
         match b {
-            b'0'..=b'9' => {},
+            b'0'..=b'9' => {}
             _ => break,
         }
         res *= 10;

--- a/day-05/part-1/badouralix.rs
+++ b/day-05/part-1/badouralix.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> String {

--- a/day-05/part-1/enizor.rs
+++ b/day-05/part-1/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[derive(Clone, Copy, Default, Debug)]

--- a/day-05/part-1/jd.rs
+++ b/day-05/part-1/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> String {

--- a/day-05/part-1/paullgdc.rs
+++ b/day-05/part-1/paullgdc.rs
@@ -1,7 +1,13 @@
 use aoc::paullgdc::{get_mut_2, tokenize::Tokenizer};
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const N: usize = 9;

--- a/day-05/part-1/thomren.rs
+++ b/day-05/part-1/thomren.rs
@@ -1,7 +1,13 @@
+use std::env::args;
 use std::str::{FromStr, Utf8Error};
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> String {

--- a/day-05/part-2/badouralix.rs
+++ b/day-05/part-2/badouralix.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> String {

--- a/day-05/part-2/enizor.rs
+++ b/day-05/part-2/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[derive(Clone, Copy, Default, Debug)]

--- a/day-05/part-2/jd.rs
+++ b/day-05/part-2/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> String {

--- a/day-05/part-2/paullgdc.rs
+++ b/day-05/part-2/paullgdc.rs
@@ -1,7 +1,13 @@
 use aoc::paullgdc::{get_mut_2, tokenize::Tokenizer};
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const N: usize = 9;

--- a/day-05/part-2/thomren.rs
+++ b/day-05/part-2/thomren.rs
@@ -1,7 +1,13 @@
+use std::env::args;
 use std::str::{FromStr, Utf8Error};
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> String {

--- a/day-06/part-1/badouralix.rs
+++ b/day-06/part-1/badouralix.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-06/part-1/enizor.rs
+++ b/day-06/part-1/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 /// Counts the number of occurences of letters using 4 bits per letter.

--- a/day-06/part-1/jd.rs
+++ b/day-06/part-1/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-06/part-1/paullgdc.rs
+++ b/day-06/part-1/paullgdc.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const WINDOW_SIZE: usize = 4;

--- a/day-06/part-1/thomren.rs
+++ b/day-06/part-1/thomren.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const MARKER_SIZE: usize = 4;

--- a/day-06/part-2/badouralix.rs
+++ b/day-06/part-2/badouralix.rs
@@ -1,7 +1,14 @@
+use std::env::args;
+use std::time::Instant;
+
 const SIZE: usize = 14;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-06/part-2/enizor.rs
+++ b/day-06/part-2/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 /// Counts the number of occurences of letters using 4 bits per letter.

--- a/day-06/part-2/jd.rs
+++ b/day-06/part-2/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-06/part-2/paullgdc.rs
+++ b/day-06/part-2/paullgdc.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const WINDOW_SIZE: usize = 14;

--- a/day-06/part-2/thomren.rs
+++ b/day-06/part-2/thomren.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const MARKER_SIZE: usize = 14;

--- a/day-07/part-1/enizor.rs
+++ b/day-07/part-1/enizor.rs
@@ -1,7 +1,13 @@
 use aoc::enizor::shell::Shell;
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-07/part-1/giltho.rs
+++ b/day-07/part-1/giltho.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const CUTOFF: u64 = 100000;
@@ -56,12 +63,10 @@ impl DirKnowledge {
         match self {
             Self::NoKnowledge => panic!("Didn't learn everything"),
             Self::Known(elems) => {
-                let (sub_answer, size) = elems
-                    .iter()
-                    .fold((0, 0), |(x, y), (_, content)| {
-                        let (xp, yp) = content.answer();
-                        (x + xp, y + yp)
-                    });
+                let (sub_answer, size) = elems.iter().fold((0, 0), |(x, y), (_, content)| {
+                    let (xp, yp) = content.answer();
+                    (x + xp, y + yp)
+                });
                 if size <= CUTOFF {
                     (sub_answer + size, size)
                 } else {

--- a/day-07/part-1/jd.rs
+++ b/day-07/part-1/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[derive(Debug)]

--- a/day-07/part-1/paullgdc.rs
+++ b/day-07/part-1/paullgdc.rs
@@ -1,17 +1,23 @@
+use std::env::args;
 use std::ops::Deref;
+use std::time::Instant;
 
 use aoc::{
     for_children,
     paullgdc::{
         arena::Handle,
         array::Array,
-        tree::Tree,
         tokenize::{parse_decimal_u32, Tokenizer},
+        tree::Tree,
     },
 };
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 type NodeName = Array<u8, 16>;

--- a/day-07/part-1/thomren.rs
+++ b/day-07/part-1/thomren.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const MAX_DIR_SIZE: usize = 100000;

--- a/day-07/part-2/enizor.rs
+++ b/day-07/part-2/enizor.rs
@@ -1,7 +1,13 @@
 use aoc::enizor::shell::Shell;
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-07/part-2/giltho.rs
+++ b/day-07/part-2/giltho.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const TOTAL_SPACE: u64 = 70000000;

--- a/day-07/part-2/jd.rs
+++ b/day-07/part-2/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[derive(Debug)]

--- a/day-07/part-2/paullgdc.rs
+++ b/day-07/part-2/paullgdc.rs
@@ -1,17 +1,23 @@
+use std::env::args;
 use std::ops::Deref;
+use std::time::Instant;
 
 use aoc::{
     for_children,
     paullgdc::{
         arena::Handle,
         array::Array,
-        tree::Tree,
         tokenize::{parse_decimal_u32, Tokenizer},
+        tree::Tree,
     },
 };
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 type NodeName = Array<u8, 16>;
@@ -146,7 +152,6 @@ fn run(input: &str) -> u32 {
     let tree = build_tree_from_output(&output).unwrap();
     let root = tree.root.unwrap();
 
-
     fn visit_sum_size(tree: &Tree<FsNode>, node: Handle) -> u32 {
         let mut sum = 0;
         for_children!(c of node node in graph tree {
@@ -159,13 +164,17 @@ fn run(input: &str) -> u32 {
             }
         });
 
-
         sum
     }
     let total_size = visit_sum_size(&tree, root);
 
     const MAX_SIZE: u32 = 40000000;
-    fn visit_min_directory(min_dir: &mut u32, total: u32, tree: &Tree<FsNode>, node: Handle) -> u32 {
+    fn visit_min_directory(
+        min_dir: &mut u32,
+        total: u32,
+        tree: &Tree<FsNode>,
+        node: Handle,
+    ) -> u32 {
         let mut sum = 0;
         for_children!(c of node node in graph tree {
             match &tree.get(c).unwrap().content {
@@ -216,7 +225,7 @@ $ ls
 8033020 d.log
 5626152 d.ext
 7214296 k"),
-24933642
+            24933642
         )
     }
 }

--- a/day-07/part-2/thomren.rs
+++ b/day-07/part-2/thomren.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const FS_TOTAL_SIZE: usize = 70000000;

--- a/day-08/part-1/badouralix.rs
+++ b/day-08/part-1/badouralix.rs
@@ -1,7 +1,13 @@
 use std::collections::HashSet;
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[allow(clippy::needless_range_loop)]

--- a/day-08/part-1/enizor.rs
+++ b/day-08/part-1/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 struct Forest<'a> {

--- a/day-08/part-1/jd.rs
+++ b/day-08/part-1/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const SIZE: usize = 99;

--- a/day-08/part-1/paullgdc.rs
+++ b/day-08/part-1/paullgdc.rs
@@ -1,7 +1,14 @@
-use aoc::paullgdc::{tokenize::Tokenizer, matrix::Matrix};
+use std::env::args;
+use std::time::Instant;
+
+use aoc::paullgdc::{matrix::Matrix, tokenize::Tokenizer};
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn parse_grid(tokenizer: &mut Tokenizer) -> Matrix<u8> {

--- a/day-08/part-1/thomren.rs
+++ b/day-08/part-1/thomren.rs
@@ -1,24 +1,35 @@
 use std::collections::HashSet;
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
-#[allow(clippy::needless_range_loop)] 
+#[allow(clippy::needless_range_loop)]
 fn run(input: &str) -> usize {
-    let trees = input.lines()
-        .map(|line| line.as_bytes().iter()
-            .map(|&x| x - b'0').collect::<Vec<u8>>())
+    let trees = input
+        .lines()
+        .map(|line| {
+            line.as_bytes()
+                .iter()
+                .map(|&x| x - b'0')
+                .collect::<Vec<u8>>()
+        })
         .collect::<Vec<Vec<u8>>>();
     let (height, width) = (trees.len(), trees[0].len());
 
-    let mut visible_trees = HashSet::<(usize,usize)>::new();
-    
+    let mut visible_trees = HashSet::<(usize, usize)>::new();
+
     for i in 0..height {
         let mut max_size = None;
         for j in 0..width {
             if max_size.is_none() || trees[i][j] > max_size.unwrap() {
-                visible_trees.insert((i,j));
+                visible_trees.insert((i, j));
                 max_size = Some(trees[i][j]);
             }
         }
@@ -28,7 +39,7 @@ fn run(input: &str) -> usize {
         let mut max_size = None;
         for i in 0..height {
             if max_size.is_none() || trees[i][j] > max_size.unwrap() {
-                visible_trees.insert((i,j));
+                visible_trees.insert((i, j));
                 max_size = Some(trees[i][j]);
             }
         }
@@ -38,7 +49,7 @@ fn run(input: &str) -> usize {
         let mut max_size = None;
         for j in (0..width).rev() {
             if max_size.is_none() || trees[i][j] > max_size.unwrap() {
-                visible_trees.insert((i,j));
+                visible_trees.insert((i, j));
                 max_size = Some(trees[i][j]);
             }
         }
@@ -48,7 +59,7 @@ fn run(input: &str) -> usize {
         let mut max_size = None;
         for i in (0..height).rev() {
             if max_size.is_none() || trees[i][j] > max_size.unwrap() {
-                visible_trees.insert((i,j));
+                visible_trees.insert((i, j));
                 max_size = Some(trees[i][j]);
             }
         }

--- a/day-08/part-2/badouralix.rs
+++ b/day-08/part-2/badouralix.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[allow(clippy::needless_range_loop)]

--- a/day-08/part-2/enizor.rs
+++ b/day-08/part-2/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 struct Forest<'a> {

--- a/day-08/part-2/jd.rs
+++ b/day-08/part-2/jd.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const SIZE: usize = 99;

--- a/day-08/part-2/paullgdc.rs
+++ b/day-08/part-2/paullgdc.rs
@@ -1,7 +1,14 @@
+use std::env::args;
+use std::time::Instant;
+
 use aoc::paullgdc::{matrix::Matrix, tokenize::Tokenizer};
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn parse_grid(tokenizer: &mut Tokenizer) -> Matrix<u8> {

--- a/day-08/part-2/thomren.rs
+++ b/day-08/part-2/thomren.rs
@@ -1,17 +1,32 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
-#[allow(clippy::needless_range_loop)] 
+#[allow(clippy::needless_range_loop)]
 fn run(input: &str) -> usize {
-    let trees = input.lines()
-        .map(|line| line.as_bytes().iter()
-            .map(|&x| x - b'0').collect::<Vec<u8>>())
+    let trees = input
+        .lines()
+        .map(|line| {
+            line.as_bytes()
+                .iter()
+                .map(|&x| x - b'0')
+                .collect::<Vec<u8>>()
+        })
         .collect::<Vec<Vec<u8>>>();
     let (height, width) = (trees.len(), trees[0].len());
 
-    (0..height).flat_map(|i| (0..width).map(move |j| (i, j)))
-        .map(|pos| scenic_score(&trees, pos)).max().unwrap_or_default()
+    (0..height)
+        .flat_map(|i| (0..width).map(move |j| (i, j)))
+        .map(|pos| scenic_score(&trees, pos))
+        .max()
+        .unwrap_or_default()
 }
 
 fn scenic_score(trees: &Vec<Vec<u8>>, pos: (usize, usize)) -> usize {
@@ -26,7 +41,7 @@ fn scenic_score(trees: &Vec<Vec<u8>>, pos: (usize, usize)) -> usize {
             j += dy;
             if i < 0 || j < 0 || i >= height || j >= width {
                 break;
-            } 
+            }
             distance += 1;
             if trees[i as usize][j as usize] >= trees[pos.0][pos.1] {
                 break;

--- a/day-09/part-1/badouralix.rs
+++ b/day-09/part-1/badouralix.rs
@@ -1,3 +1,5 @@
+use std::env::args;
+use std::time::Instant;
 use std::{cmp, collections::HashSet};
 
 struct Rope {
@@ -58,7 +60,11 @@ impl Rope {
 }
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-09/part-1/enizor.rs
+++ b/day-09/part-1/enizor.rs
@@ -1,6 +1,13 @@
 use aoc::enizor::bitset::*;
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 // Assume the rope stays in the square of size S centered on the initial position

--- a/day-09/part-1/paullgdc.rs
+++ b/day-09/part-1/paullgdc.rs
@@ -1,9 +1,15 @@
 use std::collections::HashSet;
+use std::env::args;
+use std::time::Instant;
 
 use aoc::paullgdc::tokenize::Tokenizer;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[derive(Debug)]

--- a/day-09/part-1/thomren.rs
+++ b/day-09/part-1/thomren.rs
@@ -1,8 +1,14 @@
 use core::panic;
+use std::env::args;
+use std::time::Instant;
 use std::{collections::HashSet, slice::Iter, str::FromStr};
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-09/part-2/badouralix.rs
+++ b/day-09/part-2/badouralix.rs
@@ -1,4 +1,6 @@
 use core::fmt;
+use std::env::args;
+use std::time::Instant;
 use std::{cmp, collections::HashSet};
 
 const SIZE: usize = 10;
@@ -90,7 +92,11 @@ impl fmt::Display for Rope {
 }
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> usize {

--- a/day-09/part-2/enizor.rs
+++ b/day-09/part-2/enizor.rs
@@ -1,7 +1,13 @@
 use aoc::enizor::bitset::*;
+use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const S: usize = 1024;

--- a/day-09/part-2/paullgdc.rs
+++ b/day-09/part-2/paullgdc.rs
@@ -1,9 +1,15 @@
 use std::collections::HashSet;
+use std::env::args;
+use std::time::Instant;
 
 use aoc::paullgdc::tokenize::Tokenizer;
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[derive(Debug)]

--- a/day-09/part-2/thomren.rs
+++ b/day-09/part-2/thomren.rs
@@ -1,8 +1,14 @@
 use core::panic;
+use std::env::args;
+use std::time::Instant;
 use std::{collections::HashSet, slice::Iter, str::FromStr};
 
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 const ROPE_LENGTH: usize = 10;

--- a/day-10/part-1/enizor.rs
+++ b/day-10/part-1/enizor.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 #[derive(Debug)]

--- a/lib/rust/lib.rs
+++ b/lib/rust/lib.rs
@@ -1,12 +1,2 @@
-use std::{fmt::Display, time::Instant, env::args};
-
 pub mod enizor;
 pub mod paullgdc;
-
-pub fn run<R: Display, F: FnOnce(&str) -> R>(f: F){
-    let now = Instant::now();
-    let output = f(&args().nth(1).expect("Please provide an input"));
-    let elapsed = now.elapsed();
-    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
-    println!("{}", output);    
-}

--- a/tool/templates/template.rs
+++ b/tool/templates/template.rs
@@ -1,5 +1,12 @@
+use std::env::args;
+use std::time::Instant;
+
 fn main() {
-    aoc::run(run)
+    let now = Instant::now();
+    let output = run(&args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!("_duration:{}", elapsed.as_secs_f64() * 1000.);
+    println!("{}", output);
 }
 
 fn run(input: &str) -> isize {


### PR DESCRIPTION
Partial revert of https://github.com/badouralix/adventofcode-2022/pull/21

Couple of drawbacks with `aoc::run(run)` : 

- it is inconsistent with all other non-python templates
- it does not respect the kiss principle, adding by default yet another layer of indirection for all rust solutions
- the default does not work with `_parse` which is required for https://adventofcode.com/2022/day/10#part2

The advent of code goal is not to write production code but rather quick and dirty
Better keep the run code in the solution file directly to be able to change it fast if needed